### PR TITLE
use actual runtime type of target item for FlexibleStructureBuilder

### DIFF
--- a/src/projects/Structurizer/FlexibleStructureBuilder.cs
+++ b/src/projects/Structurizer/FlexibleStructureBuilder.cs
@@ -59,7 +59,7 @@ namespace Structurizer
         {
             EnsureArg.IsNotNull(item, nameof(item));
 
-            var schema = GetSchema(typeof(T));
+            var schema = GetSchema(item.GetType());
 
             return new Structure(schema.Name, _indexesFactory.CreateIndexes(schema, item));
         }


### PR DESCRIPTION
[I have a logger with an API that allows passing of anonymous objects as event data. I use `object` as the type for the `data` parameter in my logging api.](https://github.com/andycmaj/SerilogEventLogger/blob/structurizer-as-eventdata-flattener/src/SerilogEventLogger/EventData.cs#L49)

(related to #2, #3)

Under the hood, the event logger uses structurizer to flatten the event data to a simple key value list.

my problem is that since i pass the anon object around as `object` instead of a generic type, `FlexibleStructureBuilder` doesn't have the compile-time context it needs to use `typeof(T)` as the structure schema cache key.

the result is this error:

```
 Structurizer.StructurizerException : The Item of type 'Object' has no members that are indexable. There's no point in treating items that has nothing to index.
Stack Trace:
   at Structurizer.StructureSchemaFactory.CreateSchema(IStructureType structureType)
   at System.Collections.Concurrent.ConcurrentDictionary`2.GetOrAdd(TKey key, Func`2 valueFactory)
   at Structurizer.FlexibleStructureBuilder.CreateStructure[T](T item)
   at SerilogEventLogger.EventData.AddValues(Object values) in /Workspace/github/andycmaj/SerilogEventLogger...
```

however if it uses `item.GetType()` instead, it can use the actual runtime type of the anon object as the schema cache key.